### PR TITLE
修复redis缓存页面bug

### DIFF
--- a/vue/src/views/monitor/cache/index.vue
+++ b/vue/src/views/monitor/cache/index.vue
@@ -68,7 +68,7 @@
 
 <script>
 import { getCache } from "@/api/monitor/cache";
-import echarts from "echarts";
+import * as echarts from 'echarts';
 
 export default {
   name: "Server",


### PR DESCRIPTION
修复redis缓存页面bug，echarts 5.x 图表引入方式问题，造成图表初始化失败。